### PR TITLE
Fix: Dev Container

### DIFF
--- a/.devcontainer/backend/devcontainer.json
+++ b/.devcontainer/backend/devcontainer.json
@@ -6,7 +6,7 @@
     "target": "devcontainer"
   },
   "updateRemoteUserUID": true,
-  "workspaceFolder": "/workspaces/frost/backend",
-  "postCreateCommand": "/workspaces/frost/.devcontainer/backend/post_create.sh",
+  "workspaceFolder": "/workspaces/Frost/backend",
+  "postCreateCommand": "/workspaces/Frost/.devcontainer/backend/post_create.sh",
   "shutdownAction": "none"
 }

--- a/.devcontainer/backend/post_create.sh
+++ b/.devcontainer/backend/post_create.sh
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 # Constants
 USER_NAME=vscode
 GROUP_NAME=vscode
-WORKSPACE_DIR=/workspaces/frost
+WORKSPACE_DIR=/workspaces/Frost
 BUILT_NODE_MODULES_DIR=/tmp/project_dependencies/node_modules
 NODE_MODULES_DESTINATION_PATH="${WORKSPACE_DIR}/backend/node_modules"
 

--- a/.devcontainer/backend/post_create.sh
+++ b/.devcontainer/backend/post_create.sh
@@ -12,7 +12,7 @@ NODE_MODULES_DESTINATION_PATH="${WORKSPACE_DIR}/backend/node_modules"
 
 # Dockerイメージでビルド済みの node_modules/ をワークスペースへコピー
 # ローカルで作成されたnode_modulesがあったら削除しておく
-if [ -e "$NODE_MODULES_DESTINATION_PATH" ]; then
+if [[ -e "$NODE_MODULES_DESTINATION_PATH" || -L "$NODE_MODULES_DESTINATION_PATH" ]]; then
   sudo unlink "$NODE_MODULES_DESTINATION_PATH"
 fi
 sudo ln --symbolic "$BUILT_NODE_MODULES_DIR" "$NODE_MODULES_DESTINATION_PATH"

--- a/.devcontainer/frontend/devcontainer.json
+++ b/.devcontainer/frontend/devcontainer.json
@@ -6,7 +6,7 @@
     "target": "devcontainer"
   },
   "updateRemoteUserUID": true,
-  "workspaceFolder": "/workspaces/frost/frontend",
-  "postCreateCommand": "/workspaces/frost/.devcontainer/frontend/post_create.sh",
+  "workspaceFolder": "/workspaces/Frost/frontend",
+  "postCreateCommand": "/workspaces/Frost/.devcontainer/frontend/post_create.sh",
   "shutdownAction": "none"
 }

--- a/.devcontainer/frontend/post_create.sh
+++ b/.devcontainer/frontend/post_create.sh
@@ -12,7 +12,7 @@ NODE_MODULES_DESTINATION_PATH="${WORKSPACE_DIR}/frontend/node_modules"
 
 # Dockerイメージでビルド済みの node_modules/ をワークスペースへコピー
 # ローカルで作成されたnode_modulesがあったら削除しておく
-if [ -e "$NODE_MODULES_DESTINATION_PATH" ]; then
+if [[ -e "$NODE_MODULES_DESTINATION_PATH" || -L "$NODE_MODULES_DESTINATION_PATH" ]]; then
   sudo unlink "$NODE_MODULES_DESTINATION_PATH"
 fi
 sudo ln --symbolic "$BUILT_NODE_MODULES_DIR" "$NODE_MODULES_DESTINATION_PATH"

--- a/.devcontainer/frontend/post_create.sh
+++ b/.devcontainer/frontend/post_create.sh
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 # Constants
 USER_NAME=vscode
 GROUP_NAME=vscode
-WORKSPACE_DIR=/workspaces/frost
+WORKSPACE_DIR=/workspaces/Frost
 BUILT_NODE_MODULES_DIR=/tmp/project_dependencies/node_modules
 NODE_MODULES_DESTINATION_PATH="${WORKSPACE_DIR}/frontend/node_modules"
 


### PR DESCRIPTION
## Changes
- **Fix**: リポジトリのパスの指定誤り (`frost` -> `Frost`)
- **Fix**: `node_modules`がシンボリックリンクで作成済みの場合の判定
