### PR TITLE
Environment: node_modules/の削除処理の修正

### DIFF
--- a/.devcontainer/backend/post_create.sh
+++ b/.devcontainer/backend/post_create.sh
@@ -11,8 +11,11 @@ BUILT_NODE_MODULES_DIR=/tmp/project_dependencies/node_modules
 NODE_MODULES_DESTINATION_PATH="${WORKSPACE_DIR}/backend/node_modules"
 
 # Dockerイメージでビルド済みの node_modules/ をワークスペースへコピー
-# ローカルで作成されたnode_modulesがあったら削除しておく
-if [[ -e "$NODE_MODULES_DESTINATION_PATH" || -L "$NODE_MODULES_DESTINATION_PATH" ]]; then
+# 過去に作成されたnode_modulesがあったら削除しておく
+if [ -d "$NODE_MODULES_DESTINATION_PATH" ]; then
+  sudo rm --recursive  "$NODE_MODULES_DESTINATION_PATH"
+fi
+if [ -L "$NODE_MODULES_DESTINATION_PATH" ]; then
   sudo unlink "$NODE_MODULES_DESTINATION_PATH"
 fi
 sudo ln --symbolic "$BUILT_NODE_MODULES_DIR" "$NODE_MODULES_DESTINATION_PATH"

--- a/.devcontainer/frontend/post_create.sh
+++ b/.devcontainer/frontend/post_create.sh
@@ -11,10 +11,12 @@ BUILT_NODE_MODULES_DIR=/tmp/project_dependencies/node_modules
 NODE_MODULES_DESTINATION_PATH="${WORKSPACE_DIR}/frontend/node_modules"
 
 # Dockerイメージでビルド済みの node_modules/ をワークスペースへコピー
-# ローカルで作成されたnode_modulesがあったら削除しておく
-if [[ -e "$NODE_MODULES_DESTINATION_PATH" || -L "$NODE_MODULES_DESTINATION_PATH" ]]; then
+# 過去に作成されたnode_modulesがあったら削除しておく
+if [ -d "$NODE_MODULES_DESTINATION_PATH" ]; then
+  sudo rm --recursive  "$NODE_MODULES_DESTINATION_PATH"
+fi
+if [ -L "$NODE_MODULES_DESTINATION_PATH" ]; then
   sudo unlink "$NODE_MODULES_DESTINATION_PATH"
 fi
 sudo ln --symbolic "$BUILT_NODE_MODULES_DIR" "$NODE_MODULES_DESTINATION_PATH"
 sudo chown "${USER_NAME}:${GROUP_NAME}" --recursive "$NODE_MODULES_DESTINATION_PATH"
-


### PR DESCRIPTION
## Why
`node_modules/`がWindowsホストやLinuxホストなどで既に作成されていた場合Devcontainerビルド後の削除処理に失敗する