### PR TITLE
chore: docker engine のインストール手順に警告を追加

### DIFF
--- a/docs/tech.md
+++ b/docs/tech.md
@@ -24,6 +24,8 @@ VS Code (on Linux or WSL)を想定。
    [Docker公式ドキュメントのインストール手順](https://docs.docker.com/engine/install/)を参考にDocker Engineをインストールする。
 
    ℹ️WSLの環境ではWindowsホストではなくLinuxへのDocker Engineインストールで動作を確認済みです。
+
+   ※ Snap から Docker Engine をインストールした場合、Dev Container が動かなくなるので注意すること。
 1. **リポジトリを開く**\
    VS Codeでリポジトリのディレクトリを開く。
 1. **拡張機能のインストール**\


### PR DESCRIPTION
docker engine のインストール手順に Snap では Dev Container が動作しないことを書き加えました。